### PR TITLE
Replace use of deprecated getPosition API with getAdapterPosition

### DIFF
--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile "com.android.support:support-v4:23.0.0"
     compile "com.android.support:gridlayout-v7:23.0.0"
     compile "com.android.support:cardview-v7:23.0.0"
-    compile 'com.android.support:recyclerview-v7:21.0.2'
+    compile 'com.android.support:recyclerview-v7:23.1.1'
 }
 
 // The sample build uses multiple directories to

--- a/Application/src/main/java/com/example/android/recyclerview/CustomAdapter.java
+++ b/Application/src/main/java/com/example/android/recyclerview/CustomAdapter.java
@@ -45,7 +45,7 @@ public class CustomAdapter extends RecyclerView.Adapter<CustomAdapter.ViewHolder
             v.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    Log.d(TAG, "Element " + getPosition() + " clicked.");
+                    Log.d(TAG, "Element " + getAdapterPosition() + " clicked.");
                 }
             });
             textView = (TextView) v.findViewById(R.id.textView);


### PR DESCRIPTION
This PR resolves [issue #11](https://github.com/googlesamples/android-RecyclerView/issues/11) by replacing getPosition() with getAdapterPosition().