### PR TITLE
Update SDK and JDK versions. Fix compatibility.

### DIFF
--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile "com.android.support:gridlayout-v7:27.0.2"
     compile "com.android.support:cardview-v7:27.0.2"
     compile "com.android.support:appcompat-v7:27.0.2"
-    compile 'com.android.support:recyclerview-v7:24.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.2'
 }
 
 // The sample build uses multiple directories to
@@ -39,13 +39,13 @@ android {
     buildToolsVersion "27.0.2"
 
     defaultConfig {
-        minSdkVersion 7
+        minSdkVersion 14
         targetSdkVersion 27
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     sourceSets {

--- a/Application/src/main/java/com/example/android/common/logger/LogView.java
+++ b/Application/src/main/java/com/example/android/common/logger/LogView.java
@@ -17,6 +17,7 @@ package com.example.android.common.logger;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.util.*;
 import android.support.v7.widget.AppCompatTextView;
 
@@ -92,7 +93,7 @@ public class LogView extends AppCompatTextView implements LogNode {
 
         // In case this was originally called from an AsyncTask or some other off-UI thread,
         // make sure the update occurs within the UI thread.
-        ((Activity) getContext()).runOnUiThread( (new Thread(new Runnable() {
+        (getActivity()).runOnUiThread( (new Thread(new Runnable() {
             @Override
             public void run() {
                 // Display the text we just generated within the LogView.
@@ -103,6 +104,17 @@ public class LogView extends AppCompatTextView implements LogNode {
         if (mNext != null) {
             mNext.println(priority, tag, msg, tr);
         }
+    }
+
+    private Activity getActivity() {
+        Context context = getContext();
+        while (context instanceof ContextWrapper) {
+            if (context instanceof Activity) {
+                return (Activity)context;
+            }
+            context = ((ContextWrapper)context).getBaseContext();
+        }
+        return null;
     }
 
     public LogNode getNext() {

--- a/Application/src/main/java/com/example/android/common/logger/LogView.java
+++ b/Application/src/main/java/com/example/android/common/logger/LogView.java
@@ -18,11 +18,11 @@ package com.example.android.common.logger;
 import android.app.Activity;
 import android.content.Context;
 import android.util.*;
-import android.widget.TextView;
+import android.support.v7.widget.AppCompatTextView;
 
 /** Simple TextView which is used to output log data received through the LogNode interface.
 */
-public class LogView extends TextView implements LogNode {
+public class LogView extends AppCompatTextView implements LogNode {
 
     public LogView(Context context) {
         super(context);


### PR DESCRIPTION
Updated minSDK.
Set dependecies versions to be the same.

Fixed activity call to work with current API.

More details [here](https://stackoverflow.com/questions/57234208/android-studio-gradle-doesnt-build-sample-app).